### PR TITLE
Fix silent substitution drop and add middle position validation

### DIFF
--- a/src/editor/base/edit-util/range-parser.ts
+++ b/src/editor/base/edit-util/range-parser.ts
@@ -171,7 +171,13 @@ function constructRangeFromSyntaxNode(settings: PluginSettings, range: SyntaxNod
 	let middle = undefined;
 	if (range.type.name === "Substitution") {
 		const child = metadata ? range.firstChild?.nextSibling : range.firstChild;
-		if (!child || child.type.name !== "MSub") return;
+		if (!child || child.type.name !== "MSub") {
+			console.warn(
+				`CriticMarkup: Substitution at [${range.from}, ${range.to}] dropped — ` +
+				`~> separator not found by parser. Markup will appear as literal text.`
+			);
+			return;
+		}
 		middle = child.from;
 	}
 

--- a/src/editor/base/ranges/types/substitution_range.ts
+++ b/src/editor/base/ranges/types/substitution_range.ts
@@ -3,8 +3,15 @@ import { CriticMarkupRange } from "../base_range";
 import { CM_All_Brackets, SuggestionType } from "../definitions";
 
 export class SubstitutionRange extends CriticMarkupRange {
+	private _invalid = false;
+
 	constructor(from: number, public middle: number, to: number, text: string, metadata?: number) {
 		super(from, to, SuggestionType.SUBSTITUTION, "Substitution", text, metadata);
+		const cm = this.middle - this.range_front;
+		if (cm < 3 || cm + 2 > this.text.length - 3) {
+			console.warn(`Invalid substitution range: middle position ${middle} is out of bounds for range [${from}, ${to}]`);
+			this._invalid = true;
+		}
 	}
 
 	get length() {
@@ -24,10 +31,12 @@ export class SubstitutionRange extends CriticMarkupRange {
 	}
 
 	unwrap() {
+		if (this._invalid) return "";
 		return this.text.slice(3, this.char_middle) + this.text.slice(this.char_middle + 2, -3);
 	}
 
 	unwrap_parts() {
+		if (this._invalid) return ["", ""];
 		return [
 			this.text.slice(3, this.char_middle),
 			this.text.slice(this.char_middle + 2, -3),

--- a/tests/accept_reject.test.ts
+++ b/tests/accept_reject.test.ts
@@ -176,6 +176,51 @@ describe("SubstitutionRange", () => {
 		expect(r.accept()).toBe("new");
 		expect(r.reject()).toBe("old");
 	});
+
+	test("substitution with metadata at non-zero offset", () => {
+		// Document: "Some text {~~{"author":"Bob"}@@hello~>world~~}"
+		// Substitution starts at position 10
+		const text = '{~~{"author":"Bob"}@@hello~>world~~}';
+		const from = 10;
+		// @@ is at index 19 in text, so absolute position = 10 + 19 = 29
+		const metadataPos = from + 19;
+		// ~> is at index 26 in text, so absolute position = 10 + 26 = 36
+		const middle = from + 26;
+		const to = from + text.length; // 46
+		const r = makeSubstitution(from, middle, to, text, metadataPos);
+		expect(r.fields.author).toBe("Bob");
+		expect(r.accept()).toBe("world");
+		expect(r.reject()).toBe("hello");
+	});
+
+	// ─── Issue #1: Defensive validation for invalid middle ───
+
+	test("SubstitutionRange with invalid middle (before content start) warns", () => {
+		const text = "{~~old~>new~~}";
+		const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+		// middle=1 is inside the opening bracket {~~, which is invalid
+		const r = makeSubstitution(0, 1, 14, text);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Invalid substitution")
+		);
+		// Should return safe empty strings rather than corrupted slices
+		expect(r.accept()).toBe("");
+		expect(r.reject()).toBe("");
+		warnSpy.mockRestore();
+	});
+
+	test("SubstitutionRange with invalid middle (after content end) warns", () => {
+		const text = "{~~old~>new~~}";
+		const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+		// middle=12 is inside the closing bracket ~~}, which is invalid
+		const r = makeSubstitution(0, 12, 14, text);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Invalid substitution")
+		);
+		expect(r.accept()).toBe("");
+		expect(r.reject()).toBe("");
+		warnSpy.mockRestore();
+	});
 });
 
 describe("HighlightRange", () => {


### PR DESCRIPTION
## Summary
- Adds `console.warn` when the Lezer parser can't find `~>` in a substitution, instead of silently dropping the range (fixes #1)
- Adds bounds validation in `SubstitutionRange` constructor — invalid middle positions now warn and return safe empty strings instead of corrupted text
- Adds 3 new tests (metadata at non-zero offset, invalid middle before/after content)

## Investigation of #2
Analysis shows the `char_middle` calculation with metadata is mathematically correct: the metadata stripping in the base constructor + `range_front` adjustment always compensate each other. Added defensive validation as a safety net regardless.

## Test plan
- [x] All 56 tests pass
- [x] Lint passes (only pre-existing warnings)
- [x] CI should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)